### PR TITLE
Moving setup complete file to the host

### DIFF
--- a/roles/setup/tasks/first_run.yml
+++ b/roles/setup/tasks/first_run.yml
@@ -70,8 +70,7 @@
 - name: tag environment as configured
   become: no
   file:
-    path: "{{ inventory_dir }}/.setup-complete"
+    path: "{{ app_dir }}/.setup-complete"
     state: touch
-  delegate_to: 127.0.0.1
   tags:
     - configure-confirm

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -3,13 +3,12 @@
 
 - name: determine if this is first run
   stat:
-    path: "{{ inventory_dir }}/.setup-complete"
+    path: "{{ app_dir }}/.setup-complete"
     follow: yes
     get_attributes: no
     get_checksum: no
     get_mime: no
   register: setup_stat
-  delegate_to: 127.0.0.1
   tags:
     - setup-check
 


### PR DESCRIPTION
This is making AE fail for subsequent envs. When the file is in the ansible directory, I cannot rerun setup. I moved the file to the host so it can be independent of the deployment.  