### PR TITLE
explicitly exclude the version that breaks app-factory startup model

### DIFF
--- a/roles/gunicorn/tasks/main.yml
+++ b/roles/gunicorn/tasks/main.yml
@@ -6,6 +6,7 @@
   pip:
     name: gunicorn
     virtualenv: "{{ user['home'] }}/venv"
+    version: "!=20.0.0"
   tags: pip
 
 - name: create gunicorn log directory


### PR DESCRIPTION
The most recent version of gunicorn breaks the app-factory model we're using to launch the validator.
Issue here: https://github.com/benoitc/gunicorn/issues/2159
Fix has been commited upstream: https://github.com/benoitc/gunicorn/commit/19cb68f4c3b55da22581c008659ee62d8c54ab2b#diff-5832adf374920d75d4bf48e546367f53R67
So presumably, next release will work. (Our use-case is explicitly included in the tests in that commit)
This PR changes the gunicorn install to _not_ install the one, broken, version.